### PR TITLE
Fix tests and other clean up.

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -49,7 +49,14 @@ trigger:
 pr: none
 
 pool:
-  vmImage: windows-latest
+#  vmImage: windows-latest
+    name: 'C3D Windows'
+    demands:
+    - msbuild
+    - MSBuild_17.0
+    - visualstudio
+    - Agent.OS -equals Windows_NT
+    - VisualStudio.BuildTools.Version -gtVersion 17.0
 
 variables:
 - group: Github-Packages

--- a/samples/Sample.WebApp/Program.cs
+++ b/samples/Sample.WebApp/Program.cs
@@ -31,9 +31,9 @@ public class Program
         {
             // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
             app.UseHsts();
+            app.UseHttpsRedirection();
         }
 
-        app.UseHttpsRedirection();
         app.UseStaticFiles();
 
         app.UseRouting();

--- a/src/C3D/Extensions/Playwright/AspNetCore/Factory/PlaywrightWebApplicationFactory.cs
+++ b/src/C3D/Extensions/Playwright/AspNetCore/Factory/PlaywrightWebApplicationFactory.cs
@@ -218,8 +218,11 @@ public class PlaywrightWebApplicationFactory<TProgram> : WebApplicationFactory<T
             // In chromium some ports are blocked, such as sip ports 5060/5061.
             // As these may be picked, we explicitly allow whatever port this host is running on.
             args.Add($"--explicitly-allowed-ports={Port}");
+            options = new(options)
+            {
+                Args = args
+            };
         }
-        options.Args = args;
         return await browser.LaunchAsync(options);
     }
 


### PR DESCRIPTION
Addresses random failures during testing.
Should prevent race conditions where playwright is requesting the page before the host server is started.
Add feature to allow getting both `IHost` instances and `IServer` instances from `CompositeHost` via `Services` property.
Add additional tests for Urls to match between requested, Kestrel, and Playwright.