### PR TITLE
Because xunit package depends on aspnetcore, the version also has to …

### DIFF
--- a/src/C3D/Extensions/Playwright/AspNetCore.Xunit/version.json
+++ b/src/C3D/Extensions/Playwright/AspNetCore.Xunit/version.json
@@ -1,7 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json",
 	"version": "0.1",
-	"pathFilters": [ ".", "../Directory.Build.props", "../Directory.Build.targets" ],
+	"pathFilters": [
+		".",
+		"../Directory.Build.props",
+		"../Directory.Build.targets",
+		"../AspNetCore"
+	],
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$", // we release out of main
 		"^refs/heads/rel/v\\d+\\.\\d+" // we also release tags starting with rel/N.N


### PR DESCRIPTION
…bump.